### PR TITLE
Add logic to conditionally render Expo Camera

### DIFF
--- a/screens/Main/index.js
+++ b/screens/Main/index.js
@@ -1,19 +1,18 @@
 import { useState, useRef } from 'react';
 import { Button, Text, TouchableOpacity, View } from 'react-native';
+import { useIsFocused } from '@react-navigation/native';
 import { Camera, CameraType } from 'expo-camera';
 
-import api from '../../utils/api';
 import styles from './styles';
 
-const LANG_TO = 'en';
-
 const Main = () => {
-  const [cameraReady, setCameraReady] = useState(false);
+  const isFocused = useIsFocused();
   const [cameraType, setCameraType] = useState(CameraType.back);
   const [permission, grantPermission] = Camera.useCameraPermissions();
 
   // need a ref because methods are bound to the Camera component
   const cam = useRef(null);
+  const ready = useRef(false);
 
   const toggleCameraType = () => {
     setCameraType((type) =>
@@ -23,14 +22,16 @@ const Main = () => {
 
   const analyze = async () => {
     try {
-      if (!cameraReady) {
-        throw new Error('Failed to take photo; Camera failed to mount');
+      console.log(ready);
+      if (!ready.current) {
+        throw new Error('Failed to take photo; Camera not mounted');
       }
 
-      const { base64 } = await cam.current.takePictureAsync({ base64: true });
-      const { data } = await api.analyze(base64, LANG_TO);
+      // const { base64 } = await cam.current.takePictureAsync({ base64: true });
+      // const { data } = await api.analyze(base64, LANG_TO);
 
-      console.log(data);
+      // console.log(data);
+      console.log('TAKE PHOTO');
     } catch (error) {
       console.error(error.message);
     }
@@ -55,33 +56,27 @@ const Main = () => {
 
   return (
     <View style={styles.container}>
-      <Camera
-        ref={cam}
-        style={styles.camera}
-        type={cameraType}
-        ratio='16:9'
-        onCameraReady={() => setCameraReady(() => true)}
-        onMountError={() => console.log('CAMERA MOUNT ERROR')}
-      >
-        <View style={styles.buttonContainer}>
-          <Buttons toggleCameraType={toggleCameraType} analyze={analyze} />
-        </View>
-      </Camera>
+      {isFocused && (
+        <Camera
+          ref={cam}
+          style={styles.camera}
+          type={cameraType}
+          ratio='16:9'
+          onCameraReady={() => (ready.current = true)}
+          onMountError={() => console.log('CAMERA MOUNT ERROR')}
+        >
+          <View style={styles.buttonContainer}>
+            <TouchableOpacity style={styles.button} onPress={toggleCameraType}>
+              <Text style={styles.text}>Flip Camera</Text>
+            </TouchableOpacity>
+
+            <TouchableOpacity style={styles.button} onPress={analyze}>
+              <Text style={styles.text}>Take Photo</Text>
+            </TouchableOpacity>
+          </View>
+        </Camera>
+      )}
     </View>
-  );
-};
-
-const Buttons = ({ analyze, toggleCameraType }) => {
-  return (
-    <>
-      <TouchableOpacity style={styles.button} onPress={toggleCameraType}>
-        <Text style={styles.text}>Flip Camera</Text>
-      </TouchableOpacity>
-
-      <TouchableOpacity style={styles.button} onPress={analyze}>
-        <Text style={styles.text}>Take Photo</Text>
-      </TouchableOpacity>
-    </>
   );
 };
 


### PR DESCRIPTION
Call react-navigation's `useIsFocused` hook to mount and unmount `Camera` component when navigating to and from the `Main` screen.

Per [docs](https://docs.expo.dev/versions/latest/sdk/camera/#usage), should unmount the camera when navigating to other screens to ensure expected behavior.